### PR TITLE
Correct repo urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 <hr />
 
 <p align="center">
-	<a href="https://github.com/cmss13-devs/cmss13-pve/actions?query=workflow%3A%22CI+Suite%22"><img src="https://github.com/cmss13-devs-pve/cmss13/workflows/CI%20Suite/badge.svg"></a>
- 	<a href="https://github.com/cmss13-devs/cmss13-pve/actions/workflows/generate_documentation.yml"><img src="https://github.com/cmss13-devs/cmss13-pve/actions/workflows/generate_documentation.yml/badge.svg"></a>
+	<a href="https://github.com/cmss13-devs/cmss13-pve-halo/actions?query=workflow%3A%22CI+Suite%22"><img src="https://github.com/cmss13-devs/cmss13-pve-halo/workflows/CI%20Suite/badge.svg"></a>
+ 	<a href="https://github.com/cmss13-devs/cmss13-pve-halo/actions/workflows/generate_documentation.yml"><img src="https://github.com/cmss13-devs/cmss13-pve-halo/actions/workflows/generate_documentation.yml/badge.svg"></a>
 </p>
 
 <p align="center">

--- a/tools/mapmerge2/fixup.py
+++ b/tools/mapmerge2/fixup.py
@@ -60,7 +60,7 @@ def main(repo : pygit2.Repository):
 
     # Set up upstream remote if needed
     try:
-        repo.remotes.create("upstream", "https://github.com/cmss13-devs/cmss13-pve.git")
+        repo.remotes.create("upstream", "https://github.com/cmss13-devs/cmss13-pve-halo.git")
     except ValueError:
         pass
     else:


### PR DESCRIPTION
# About the pull request

This PR simply updates some pve repo urls that should have been pve-halo repo urls.

## Important
**If you have ran the mapmerge fixup script (I Forgot To Map Merge.bat) you need to correct your upstream remote. Please run this command to point it to the correct repo:**
`git remote set-url upstream https://github.com/cmss13-devs/cmss13-pve-halo.git`

# Explain why it's good for the game

Fixes pve halo tooling and readme.

# Changelog

No player facing changes.
