### PR TITLE
Ammo economy rework

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -142,7 +142,7 @@
 		list("POUCHES", -1, null, null, null),
 		list("First-Aid Pouch", floor(scale * 15), /obj/item/storage/pouch/firstaid, VENDOR_ITEM_REGULAR),
 		list("Flare Pouch (Full)", floor(scale * 15), /obj/item/storage/pouch/flare/full, VENDOR_ITEM_REGULAR),
-		list("Magazine Pouch", floor(scale * 15), /obj/item/storage/pouch/magazine, VENDOR_ITEM_REGULAR),
+		list("Large Magazine Pouch", floor(scale * 15), /obj/item/storage/pouch/magazine/large, VENDOR_ITEM_REGULAR),
 		list("Medium General Pouch", floor(scale * 15), /obj/item/storage/pouch/general/medium, VENDOR_ITEM_REGULAR),
 		list("Pistol Magazine Pouch", floor(scale * 15), /obj/item/storage/pouch/magazine/pistol/unsc, VENDOR_ITEM_REGULAR),
 		list("Pistol Pouch", floor(scale * 15), /obj/item/storage/pouch/pistol/unsc, VENDOR_ITEM_REGULAR),

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -558,7 +558,7 @@
 	icon_state = "marinebelt"
 	item_state = "marinebelt"
 	w_class = SIZE_LARGE
-	storage_slots = 5
+	storage_slots = 10
 	max_w_class = SIZE_MEDIUM
 	max_storage_space = 20
 	can_hold = list(

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -1391,9 +1391,15 @@
 	hold = /obj/item/storage/internal/accessory/webbing/m3mag
 
 /obj/item/storage/internal/accessory/webbing/m3mag
+	storage_slots = 5
 	can_hold = list(
+		/obj/item/attachable/bayonet,
+		/obj/item/device/flashlight/flare,
 		/obj/item/ammo_magazine/rifle,
-		/obj/item/ammo_magazine/smg/m39,
+		/obj/item/ammo_magazine/smg,
+		/obj/item/ammo_magazine/pistol,
+		/obj/item/ammo_magazine/revolver,
+		/obj/item/ammo_magazine/sniper,
 	)
 
 //Partial Pre-load For Props
@@ -1402,6 +1408,8 @@
 	hold = /obj/item/storage/internal/accessory/webbing/m3mag/ma5c
 
 /obj/item/storage/internal/accessory/webbing/m3mag/ma5c/fill_preset_inventory()
+	new /obj/item/ammo_magazine/rifle/halo/ma5c(src)
+	new /obj/item/ammo_magazine/rifle/halo/ma5c(src)
 	new /obj/item/ammo_magazine/rifle/halo/ma5c(src)
 	new /obj/item/ammo_magazine/rifle/halo/ma5c(src)
 	new /obj/item/ammo_magazine/rifle/halo/ma5c(src)

--- a/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
@@ -1234,24 +1234,24 @@
 	flags_equip_slot = null
 
 /obj/item/ammo_box/magazine/unsc/ma5c
-	name = "UNSC magazine box (MA5C x 26)"
-	desc = "An ammo box storing 26 magazines of MA5C ammunition"
+	name = "UNSC magazine box (MA5C x 48)"
+	desc = "An ammo box storing 48 magazines of MA5C ammunition"
 	icon_state = "base_ammo"
 	overlay_ammo_type = "_reg"
 	overlay_content = "_reg"
 	overlay_gun_type = "_ma5c"
 	magazine_type = /obj/item/ammo_magazine/rifle/halo/ma5c
-	num_of_magazines = 26
+	num_of_magazines = 48
 
 /obj/item/ammo_box/magazine/unsc/br55
-	name = "UNSC magazine box (BR55 x 26)"
-	desc = "An ammo box storing 26 magazines of BR55 ammunition"
+	name = "UNSC magazine box (BR55 x 32)"
+	desc = "An ammo box storing 32 magazines of BR55 ammunition"
 	icon_state = "base_ammo"
 	overlay_ammo_type = "_reg"
 	overlay_content = "_reg"
 	overlay_gun_type = "_br55"
 	magazine_type = /obj/item/ammo_magazine/rifle/halo/br55
-	num_of_magazines = 26
+	num_of_magazines = 32
 
 /obj/item/ammo_box/magazine/unsc/small
 	name = "UNSC magazine box"
@@ -1260,20 +1260,20 @@
 	overlay_gun_type = null
 
 /obj/item/ammo_box/magazine/unsc/small/m6c
-	name = "UNSC magazine box (M6C x 14)"
-	desc = "An ammo box storing 14 magazines of M6C ammunition."
+	name = "UNSC magazine box (M6C x 22)"
+	desc = "An ammo box storing 22 magazines of M6C ammunition."
 	icon_state = "base_ammosmall"
 	overlay_ammo_type = "_regsmall"
 	overlay_content = "_small"
 	magazine_type = /obj/item/ammo_magazine/pistol/halo/m6c
-	num_of_magazines = 14
+	num_of_magazines = 22
 
 
 /obj/item/ammo_box/magazine/unsc/small/m6g
-	name = "UNSC magazine box (M6G x 14)"
-	desc = "An ammo box storing 14 magazines of M6G ammunition."
+	name = "UNSC magazine box (M6G x 22)"
+	desc = "An ammo box storing 22 magazines of M6G ammunition."
 	icon_state = "base_ammosmall2"
 	overlay_ammo_type = "_regsmall"
 	overlay_content = "_small"
 	magazine_type = /obj/item/ammo_magazine/pistol/halo/m6g
-	num_of_magazines = 14
+	num_of_magazines = 22

--- a/code/modules/projectiles/guns/halo/unsc_magazines.dm
+++ b/code/modules/projectiles/guns/halo/unsc_magazines.dm
@@ -9,9 +9,9 @@
 
 /obj/item/ammo_magazine/rifle/halo/ma5c
 	name = "\improper MA5C magazine (7.62x51mm FMJ)"
-	desc = "A rectangular box magazine for the MA5C holding 60 rounds of 7.62x51 FMJ ammunitions."
+	desc = "A rectangular box magazine for the MA5C holding 48 rounds of 7.62x51 FMJ ammunitions."
 	icon_state = "ma5c"
-	max_rounds = 60
+	max_rounds = 48
 	gun_type = /obj/item/weapon/gun/rifle/halo/ma5c
 	default_ammo = /datum/ammo/bullet/rifle/ma5c
 	caliber = "7.62x51"
@@ -36,9 +36,9 @@
 
 /obj/item/ammo_magazine/rifle/halo/br55
 	name = "\improper BR55 magazine (9.5x40mm X-HP SAP-HE)"
-	desc = "A rectangular box magazine for the BR55 holding 48 rounds of 9.5x40mm X-HP SAP-HE ammunitions."
+	desc = "A rectangular box magazine for the BR55 holding 36 rounds of 9.5x40mm X-HP SAP-HE ammunitions."
 	icon_state = "br55"
-	max_rounds = 48
+	max_rounds = 36
 	gun_type = /obj/item/weapon/gun/rifle/halo/br55
 	default_ammo = /datum/ammo/bullet/rifle/br55
 	caliber = "9.5x40mm"

--- a/maps/map_files/unsc_dark_was_the_night/unsc_dark_was_the_night.dmm
+++ b/maps/map_files/unsc_dark_was_the_night/unsc_dark_was_the_night.dmm
@@ -2044,16 +2044,16 @@
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/ammo_box/magazine/unsc/ma5c{
 	pixel_x = 4;
-	pixel_y = 9
+	pixel_y = 12
 	},
 /obj/item/ammo_box/magazine/unsc/ma5c{
-	pixel_x = 0;
-	pixel_y = 18
+	pixel_y = 23
 	},
 /obj/structure/machinery/light/double/blue{
 	light_color = "#dae2ff";
 	dir = 1
 	},
+/obj/item/ammo_box/magazine/unsc/ma5c,
 /turf/open/floor/almayer/plating_striped,
 /area/dark_was_the_night/armory)
 "eN" = (
@@ -4731,7 +4731,9 @@
 	pixel_x = 6;
 	pixel_y = 19
 	},
-/obj/item/weapon/gun/shotgun/pump/halo/m90/unloaded,
+/obj/item/ammo_box/magazine/unsc/br55{
+	pixel_y = 4
+	},
 /turf/open/floor/almayer/plating_striped,
 /area/dark_was_the_night/armory)
 "mM" = (
@@ -6400,13 +6402,15 @@
 	pixel_x = 2;
 	pixel_y = 9
 	},
-/obj/item/ammo_box/magazine/unsc/small/m6g,
+/obj/item/ammo_box/magazine/unsc/small/m6g{
+	pixel_x = 4
+	},
 /obj/item/ammo_box/magazine/unsc/small/m6c{
 	pixel_x = 2;
 	pixel_y = 18
 	},
 /obj/item/ammo_box/magazine/unsc/small/m6g{
-	pixel_x = 0;
+	pixel_x = 5;
 	pixel_y = 9
 	},
 /turf/open/floor/almayer/plating_striped,
@@ -12727,17 +12731,18 @@
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/ammo_box/magazine/misc/unsc/grenade{
 	pixel_x = -6;
-	pixel_y = 6
+	pixel_y = 16
 	},
 /obj/item/ammo_box/magazine/misc/unsc/grenade{
 	pixel_x = 4;
-	pixel_y = 12;
+	pixel_y = 22;
 	layer = 3
 	},
 /obj/item/ammo_box/magazine/misc/unsc/grenade/launchable{
 	pixel_x = 11;
-	pixel_y = 3
+	pixel_y = 12
 	},
+/obj/item/weapon/gun/shotgun/pump/halo/m90/unloaded,
 /turf/open/floor/almayer/plating_striped,
 /area/dark_was_the_night/armory)
 "XB" = (


### PR DESCRIPTION

# About the pull request

Changes the max rounds of some magazines and the max amount of magazines for ammo boxes.

# Explain why it's good for the game

Reloading more is cool, and marines need more magazines in general as people often didn't get any without GM intervention in ops.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Ammo economy rework
balance: MA5C mags now hold 48 rounds instead of 60, BRs hold 36 rounds instead of 48.
balance: Magazine box storable magazines buffed
maptweak: Added more ammo boxes to the armory
/:cl:
