### PR TITLE
Fixes area on ODST DWTN

### DIFF
--- a/maps/map_files/unsc_dark_was_the_night_odst/unsc_dark_was_the_night_odst.dmm
+++ b/maps/map_files/unsc_dark_was_the_night_odst/unsc_dark_was_the_night_odst.dmm
@@ -12149,7 +12149,7 @@ Be
 IP
 bJ
 bJ
-bM
+bJ
 rR
 rR
 rR
@@ -12301,7 +12301,7 @@ BJ
 IP
 sF
 ls
-bM
+bJ
 rR
 rR
 rR
@@ -12453,7 +12453,7 @@ rf
 Lc
 sF
 bN
-bM
+bJ
 rR
 rR
 rR
@@ -12605,7 +12605,7 @@ Be
 qL
 sF
 ls
-bM
+bJ
 rR
 rR
 rR
@@ -12757,7 +12757,7 @@ bm
 qL
 bJ
 bJ
-bM
+bJ
 rR
 rR
 rR


### PR DESCRIPTION

# About the pull request

Fixed issue.

# Explain why it's good for the game

Issues are bad.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Fixed missing area on ODST DWTN upper armory
/:cl:
