### PR TITLE
Fixes medical packets

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -970,7 +970,7 @@
 	desc = "A combat-rated first aid medical packet filled with the bare bones basic essentials to ensuring you or your buddies don't die on the battlefield."
 	icon_state = "medical_packet"
 	storage_slots = 5
-	max_w_class = 0
+	max_w_class = 3
 	can_hold = list(
 		/obj/item/reagent_container/hypospray/autoinjector/biofoam/small,
 		/obj/item/stack/medical/advanced/bruise_pack,


### PR DESCRIPTION

# About the pull request

Medical packets can now have their contents put back in them

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Medical packets now can have their contents put back in them
/:cl:
