### PR TITLE
Chapter Titles Admin Notif

### DIFF
--- a/code/modules/admin/game_master/extra_buttons/chapter_title.dm
+++ b/code/modules/admin/game_master/extra_buttons/chapter_title.dm
@@ -70,6 +70,7 @@
 	if(!chapter_title)
 		return
 	message_admins("[src] has displayed a chapter title; '[chapter_title]'")
+	notify_ghosts(message = "<span style='font-weight: bold;'>The chapter title '[chapter_title]' has been played.\n</span>")
 	for(var/mob/living/carbon/human/human as anything in GLOB.human_mob_list)
 		if(human.client)
 			human.display_chapter_title("<span class='maptext' style=font-size:10pt;font-family:Verdana;text-align:left valign='bottom'>[chapter_title]", /atom/movable/screen/text/screen_text/chapter_title)


### PR DESCRIPTION
# You know, technically this makes me a contributor

Inserts a single line to give GMs an admin-log whenever a chapter title is displayed.
(Now notifies ghosts too!)

# Explain why it's good for the game

Chapter titles do not display for those ghosted or otherwise not playing, and if multiple GMs are running things this can cause confusion with triggering chapter titles.

# Testing Photographs and Procedure

<img width="579" height="15" alt="image" src="https://github.com/user-attachments/assets/b14487c3-ad18-41e2-b05d-5e54c5b2b9d8" />

# Changelog

:cl:
add: added admin and ghost notif for chapter titles
admin: yippee
/:cl:
