### PR TITLE
Flavor text touchup

### DIFF
--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -958,7 +958,7 @@
 	time_to_equip = 10
 /obj/item/clothing/suit/marine/unsc
 	name = "\improper M52B body armor"
-	desc = "Standard-issue to the UNSC Marine Corps, the M52B armor entered service by 2531 for use in the Human Covenant war, coming with improved protection against plasma-based projectiles compared to older models."
+	desc = "Standard-issue to the UNSC Marine Corps, the M52B armor entered service by 2531 for use in the Human Covenant war. A tweaked Titanium-A composition offers a jump in directed energy protection, though not nearly as much as hoped."
 	icon = 'icons/halo/obj/items/clothing/suits/suits_by_faction/suit_unsc.dmi'
 	icon_state = "m52b"
 	item_state = "m52b"

--- a/code/modules/clothing/under/halo/unsc_ties.dm
+++ b/code/modules/clothing/under/halo/unsc_ties.dm
@@ -215,8 +215,8 @@
 	)
 
 /obj/item/clothing/accessory/storage/webbing/m52b/grenade
-	name = "\improper M52B Pattern Grenade Webbing"
-	desc = "Grenadier configuration designed for standard 40mm grenades. By happy circumstance, the loops can also secure standard issue M9s. Composed of heat-resistant synthetic fabrics, this LBE attaches directly to M52B armor hardpoints with a buckle system."
+	name = "\improper M52B Pattern Grenade Pouch"
+	desc = "LBE configuration designed for grenadiers, holding standard 40mm grenades. May also secure M9s for the more old fashioned grenadier. Composed of heat-resistant synthetic fabrics, this LBE attaches directly to M52B armor hardpoints with a buckle system."
 	icon_state = "m52b_grenadewebbing"
 	hold = /obj/item/storage/internal/accessory/black_vest/m52bgrenade
 

--- a/code/modules/clothing/under/halo/unsc_ties.dm
+++ b/code/modules/clothing/under/halo/unsc_ties.dm
@@ -216,7 +216,7 @@
 
 /obj/item/clothing/accessory/storage/webbing/m52b/grenade
 	name = "\improper M52B Pattern Grenade Pouch"
-	desc = "LBE configuration designed for grenadiers, holding standard 40mm grenades. May also secure M9s for the more old fashioned grenadier. Composed of heat-resistant synthetic fabrics, this LBE attaches directly to M52B armor hardpoints with a buckle system."
+	desc = "LBE configuration designed for grenadiers, holding standard 40mm grenades. May also secure M9s for the more old fashioned grenadier. Composed of heat-resistant synthetic fabrics, tough and time tested."
 	icon_state = "m52b_grenadewebbing"
 	hold = /obj/item/storage/internal/accessory/black_vest/m52bgrenade
 

--- a/code/modules/clothing/under/halo/unsc_ties.dm
+++ b/code/modules/clothing/under/halo/unsc_ties.dm
@@ -132,7 +132,7 @@
 
 /obj/item/clothing/accessory/storage/webbing/m52b
 	name = "\improper M52B Pattern Webbing"
-	desc = "General purpose storage configuration. Composed of heat-resistant synthetic fabrics, this LBE attaches directly to M52B armor hardpoints with a buckle system."
+	desc = "General purpose storage configuration. Composed of heat-resistant synthetic fabrics, buckles to M52B armor hardpoints."
 	icon = 'icons/halo/obj/items/clothing/accessories/accessories.dmi'
 	icon_state = "m52b_webbing"
 	hold = /obj/item/storage/internal/accessory/webbing/m52bgeneric
@@ -148,7 +148,7 @@
 
 /obj/item/clothing/accessory/storage/webbing/m52b/mag
 	name = "\improper M52B Pattern Magazine Webbing"
-	desc = "A configuration of the standard webbing for weapon magazines. Composed of heat-resistant synthetic fabrics, this LBE attaches directly to M52B armor hardpoints with a buckle system. Set up as a five-pouch."
+	desc = "Magazine pouch configuration. Set up as a five-pouch."
 	icon_state = "m52b_magwebbing"
 	hold = /obj/item/storage/internal/accessory/webbing/m52bmag
 
@@ -192,7 +192,7 @@
 
 /obj/item/clothing/accessory/storage/webbing/m52b/shotgun
 	name = "\improper M52B Pattern Shell Webbing"
-	desc = "A configuration of the regular webbing for shotgun shells. Composed of heat-resistant synthetic fabrics, this LBE attaches directly to M52B armor hardpoints with a buckle system. Increasingly common for close combat operations and security forces in the new war."
+	desc = "Fast-draw shotgun shell configuration. Increasingly common for close combat operations and security forces in the new war."
 	icon_state = "m52b_shotgunwebbing"
 	hold = /obj/item/storage/internal/accessory/black_vest/m52bshotgun
 
@@ -203,7 +203,7 @@
 
 /obj/item/clothing/accessory/storage/webbing/m52b/small
 	name = "\improper M52B Pattern Small Pouch Webbing"
-	desc = "Utility configuration for storing various items in convenient pouches. Composed of heat-resistant synthetic fabrics, this LBE attaches directly to M52B armor hardpoints with a buckle system."
+	desc = "Utility configuration for storing various items in convenient pouches."
 	icon_state = "m52b_smallwebbing"
 	hold = /obj/item/storage/internal/accessory/black_vest/m52bgeneric
 	slot = ACCESSORY_SLOT_M3UTILITY
@@ -216,7 +216,7 @@
 
 /obj/item/clothing/accessory/storage/webbing/m52b/grenade
 	name = "\improper M52B Pattern Grenade Pouch"
-	desc = "LBE configuration designed for grenadiers, holding standard 40mm grenades. May also secure M9s for the more old fashioned grenadier. Composed of heat-resistant synthetic fabrics, tough and time tested."
+	desc = "LBE configuration designed for grenadiers, holding standard 40mm grenades. May also secure M9s for the more old fashioned grenadier."
 	icon_state = "m52b_grenadewebbing"
 	hold = /obj/item/storage/internal/accessory/black_vest/m52bgrenade
 

--- a/code/modules/clothing/under/halo/unsc_ties.dm
+++ b/code/modules/clothing/under/halo/unsc_ties.dm
@@ -1,8 +1,8 @@
 //===========================//CUSTOM ARMOR COSMETIC PLATES\\================================\\
 
 /obj/item/clothing/accessory/pads/unsc
-	name = "\improper M52B Shoulder Pads"
-	desc = "A set shoulder pads attachable to the M52B armor set worn by the UNSC."
+	name = "\improper M52B Pauldrons"
+	desc = "A pair of Ti-A pauldrons attachable to the UNSCMC's M52B armor for shoulder and upper arm protection."
 	icon = 'icons/halo/obj/items/clothing/accessories/accessories.dmi'
 	icon_state = "pads"
 	item_state = "pads"
@@ -11,52 +11,52 @@
 	accessory_icons = list(WEAR_BODY = 'icons/halo/mob/humans/onmob/clothing/accessories/accessories.dmi', WEAR_JACKET = 'icons/halo/mob/humans/onmob/clothing/accessories/accessories.dmi')
 
 /obj/item/clothing/accessory/pads/unsc/bracers
-	name = "\improper M52B Arm Bracers"
-	desc = "A set arm bracers worn in conjunction to the M52B body armor of the UNSC."
+	name = "\improper M52B Vambraces"
+	desc = "A pair of composite vambraces attachable to the UNSCMC's M52B armor for forearm protection. "
 	icon_state = "bracers"
 	item_state = "bracers"
 	slot = ACCESSORY_SLOT_DECORBRACER
 	flags_atom = NO_SNOW_TYPE
 
 /obj/item/clothing/accessory/pads/unsc/bracers/police
-	name = "\improper Police Shoulder Bracers"
-	desc = "A set arm bracers worn in conjunction to an armoured vest, commonly issued to Police forces."
+	name = "\improper Police Arm Guards"
+	desc = "Supplementary protection for ballistic vests, commonly seen in police service. Resists lower power ammunition readily, as well as blunt impact."
 	icon_state = "bracers_police"
 	item_state = "bracers_police"
 
 /obj/item/clothing/accessory/pads/unsc/neckguard
-	name = "\improper M52B Neck Guard"
-	desc = "An attachable neck guard option for the M52B body armor worn by the UNSC."
+	name = "\improper M52B Throat Guard"
+	desc = "An optional throat guard for the UNSCMC's M52B armor, designed to resist splinters and some lower powered ammunition."
 	icon_state = "neckguard"
 	item_state = "neckguard"
 	slot = ACCESSORY_SLOT_DECORNECK
 	flags_atom = NO_SNOW_TYPE
 
 /obj/item/clothing/accessory/pads/unsc/neckguard/police
-	name = "\improper Police Neck Guard"
-	desc = "An attachable neck guard option for basic ballistic vests, commonly issued to the Police."
+	name = "\improper Police Throat Guard"
+	desc = "Supplementary protection for ballistic vests, commonly seen in police service as a cheap up-armor for riot protection and high threat situations."
 	icon_state = "neckguard_police"
 	item_state = "neckguard_police"
 
 /obj/item/clothing/accessory/pads/unsc/greaves
-	name = "\improper M52B Shin Guards"
-	desc = "A set shinguards designed to be worn in conjuction with M52B body armor."
+	name = "\improper M52B Greaves"
+	desc = "A pair of composite partial length greaves for the UNSCMC's M52B armor. Intended for use alongside the VZG7 boots' armor protection, offering shrapnel, splinter, and cut protection."
 	icon_state = "shinguards"
 	item_state = "shinguards"
 	slot = ACCESSORY_SLOT_DECORSHIN
 	flags_atom = NO_SNOW_TYPE
 
 /obj/item/clothing/accessory/pads/unsc/groin
-	name = "\improper M52B Groin Plate"
-	desc = "A plate designed to attach to M52B body armor to protect the babymakers of the Corps. Standardized protection of the UNSC often seen worn more often than not."
+	name = "\improper M52B Lap Panel"
+	desc = "Supplementary abdominal and groin protection for the UNSCMC's M52B armor. Titanium-A incorporation offers surprising resistance to gunfire and directed energy grazes."
 	icon_state = "groinplate"
 	item_state = "groinplate"
 	slot = ACCESSORY_SLOT_DECORGROIN
 	flags_atom = NO_SNOW_TYPE
 
 /obj/item/clothing/accessory/pads/unsc/groin/police
-	name = "\improper Police Groin Plate"
-	desc = "A plate designed to attach to an armoured Vest to protect the babymakers. Most commonly attached to Police Vests."
+	name = "\improper Police Lap Panel"
+	desc = "Additional protection for ballistic vests, covering the lower abdomen and groin. Protects vital arteries and organs from low powered weapons and ricochets. Seen most commonly in police service."
 	icon_state = "groinplate_police"
 	item_state = "groinplate_police"
 
@@ -81,26 +81,26 @@
 	item_state = "groinplate_insurgent"
 
 /obj/item/clothing/accessory/pads/unsc/odst
-	name = "\improper M70DT Shoulder Pads"
-	desc = "A set shoulder pads attachable to the M70DT armor set worn by the ODSTs."
+	name = "\improper M70DT Pauldrons"
+	desc = "A pair of Ti-A pauldrons for the ODST standard issue M70DT armor set, offering shoulder protection. Commonly takes a medical reference panel."
 	icon_state = "odst_pads"
 	item_state = "odst_pads"
 
 /obj/item/clothing/accessory/pads/unsc/bracers/odst
-	name = "\improper M70DT Bracers"
-	desc = "A set arm bracers worn in conjunction to the M70DT body armor of the ODSTs."
+	name = "\improper M70DT Vambraces"
+	desc = "A pair of Ti-A vambraces for the ODST standard issue M70DT armor set."
 	icon_state = "odst_bracers"
 	item_state = "odst_bracers"
 
 /obj/item/clothing/accessory/pads/unsc/greaves/odst
 	name = "\improper M70DT Greaves"
-	desc = "A set greaves designed to be worn in conjuction with M70DT body armor."
+	desc = "A pair of Ti-A greaves for the ODST standard issue M70DT armor set. By force procurement specification, the M70DT set does not use the VZG7 design for equipment tailorability reasons, so these are full length."
 	icon_state = "odst_shinguards"
 	item_state = "odst_shinguards"
 
 /obj/item/clothing/accessory/pads/unsc/groin/odst
-	name = "\improper M70DT Groin Plate"
-	desc = "A plate designed to attach to M70DT body armor to protect the babymakers of the Corps. Standardized protection of the ODSTs often seen worn more often than not."
+	name = "\improper M70DT Lap Panel"
+	desc = "Abdomen and groin protection for the ODST standard issue M70DT armor set. Titanium-A plates increase protection significantly."
 	icon_state = "odst_groinplate"
 	item_state = "odst_groinplate"
 
@@ -132,7 +132,7 @@
 
 /obj/item/clothing/accessory/storage/webbing/m52b
 	name = "\improper M52B Pattern Webbing"
-	desc = "A sturdy mess of synthcotton belts and buckles designed to attach to the M52B body armor armor standard for the UNSC. This one is the slimmed down model designed for general purpose storage."
+	desc = "General purpose storage configuration. Composed of heat-resistant synthetic fabrics, this LBE attaches directly to M52B armor hardpoints with a buckle system."
 	icon = 'icons/halo/obj/items/clothing/accessories/accessories.dmi'
 	icon_state = "m52b_webbing"
 	hold = /obj/item/storage/internal/accessory/webbing/m52bgeneric
@@ -148,7 +148,7 @@
 
 /obj/item/clothing/accessory/storage/webbing/m52b/mag
 	name = "\improper M52B Pattern Magazine Webbing"
-	desc = "A variant of the M52B pattern webbing that features pouches for pulse rifle magazines."
+	desc = "A configuration of the standard webbing for weapon magazines. Composed of heat-resistant synthetic fabrics, this LBE attaches directly to M52B armor hardpoints with a buckle system. Set up as a five-pouch."
 	icon_state = "m52b_magwebbing"
 	hold = /obj/item/storage/internal/accessory/webbing/m52bmag
 
@@ -192,7 +192,7 @@
 
 /obj/item/clothing/accessory/storage/webbing/m52b/shotgun
 	name = "\improper M52B Pattern Shell Webbing"
-	desc = "A slightly modified variant of the M52B pattern webbing, fitted for 12 gauge shotgun shells."
+	desc = "A configuration of the regular webbing for shotgun shells. Composed of heat-resistant synthetic fabrics, this LBE attaches directly to M52B armor hardpoints with a buckle system. Increasingly common for close combat operations and security forces in the new war."
 	icon_state = "m52b_shotgunwebbing"
 	hold = /obj/item/storage/internal/accessory/black_vest/m52bshotgun
 
@@ -203,7 +203,7 @@
 
 /obj/item/clothing/accessory/storage/webbing/m52b/small
 	name = "\improper M52B Pattern Small Pouch Webbing"
-	desc = "A set of M52B pattern webbing fully outfitted with pouches and pockets to carry a while array of small items."
+	desc = "Utility configuration for storing various items in convenient pouches. Composed of heat-resistant synthetic fabrics, this LBE attaches directly to M52B armor hardpoints with a buckle system."
 	icon_state = "m52b_smallwebbing"
 	hold = /obj/item/storage/internal/accessory/black_vest/m52bgeneric
 	slot = ACCESSORY_SLOT_M3UTILITY
@@ -216,7 +216,7 @@
 
 /obj/item/clothing/accessory/storage/webbing/m52b/grenade
 	name = "\improper M52B Pattern Grenade Webbing"
-	desc = "A variation of the M52B pattern webbing fitted with loops for storing M40 grenades."
+	desc = "Grenadier configuration designed for standard 40mm grenades. By happy circumstance, the loops can also secure standard issue M9s. Composed of heat-resistant synthetic fabrics, this LBE attaches directly to M52B armor hardpoints with a buckle system."
 	icon_state = "m52b_grenadewebbing"
 	hold = /obj/item/storage/internal/accessory/black_vest/m52bgrenade
 

--- a/code/modules/projectiles/guns/halo/unsc_guns.dm
+++ b/code/modules/projectiles/guns/halo/unsc_guns.dm
@@ -733,7 +733,6 @@
 	empty_click = 'sound/weapons/halo/m6d/gun_m6d_dryfire.ogg'
 
 /obj/item/weapon/gun/pistol/halo/m6g/unloaded
-//voibs. wrong magnum.
 	current_mag = null
 
 /obj/item/weapon/gun/pistol/halo/m6d/set_gun_attachment_offsets()

--- a/code/modules/projectiles/guns/halo/unsc_guns.dm
+++ b/code/modules/projectiles/guns/halo/unsc_guns.dm
@@ -14,7 +14,7 @@
 
 /obj/item/weapon/gun/rifle/halo/ma5c
 	name = "MA5C ICWS assault rifle"
-	desc = "The MA5C Misriah Armory Individual Combat Weapons System is a 7.62x51mm bullpup, integrating an electronic round counter, HUD link, and a slew of improvements from the B-variant. Most notable is a reduced 1:7 twist rate offering higher accuracy, reworked contact surfaces for stability in automatic fire, and a completely redesigned 48 round high reliability magazine. As an unintended benefit, the new mechanism and slower twist has actually resulted in a slightly higher muzzle velocity."
+	desc = "A 7.62x51mm bullpup offering a slew of improvements from the B-variant. Reduced 1:7 twist and redesigned contact surfaces increase accuracy and stability in automatic, while the new 48 round magazine is highly reliable."
 	icon_state = "ma5c"
 	item_state = "ma5c"
 	caliber = "7.62x51mm"
@@ -70,7 +70,8 @@
 
 /obj/item/weapon/gun/rifle/halo/ma5b
 	name = "MA5B ICWS assault rifle"
-	desc = "The older weapon sports a torrential 900RPM cyclic backed by 60 round magazine. Veterans and units expecting closer combat often select the B-variant if at all possible. However, these strengths would drive its successor's adoption. While beloved by paper soldiers, it is violently unstable in automatic, and in semi its MOA wider. Magazines must be cared for carefully, or failures a few hundred rounds in are almost certain."
+	desc = "The older weapon sports a torrential 900RPM cyclic backed by 60 round magazine. Veterans and units expecting closer combat often select the B-variant if at all possible. However, these strengths would drive its successor's adoption."
+	desc_lore = "While beloved by paper soldiers in all positions, it is violently unstable in automatic, and in semi its MOA wider. Even the saltiest veteran will admit the MA5C's practically hugging its user even in full auto, compared to the 'B. Even this might not have been enough but for its reliability problem. Magazines must be cared for carefully, or failures are frequent. In the desperate combat of the early Human-Covenant War, such care evaporated."
 	icon_state = "ma5b"
 	item_state = "ma5b"
 	caliber = "7.62x51mm"
@@ -131,7 +132,8 @@
 
 /obj/item/weapon/gun/rifle/halo/ma3a
 	name = "MA3A assault rifle"
-	desc = "The MA5's predecessor had a notably short service history before being replaced by the more comprehensively designed MA5 series, though surplus from its large production run would often crop up in private security or rebel hands. Lacking the integrated combat suite of the MA5 rifles, the MA3A instead most commonly featured a over-designed and prone to malfunction multi-mode conventional computer optic. While robust in its capabilities, the constant adjustments and poor battery-life led to its quick abandonment by mainline UNSCDF units."
+	desc = "The MA5's predecessor had a notably short service history before being replaced by the more comprehensively designed MA5 series, though surplus from its large production run would often crop up in private security or rebel hands."
+	desc_lore = " Lacking the integrated combat suite of the MA5 rifles, the MA3A instead most commonly featured a over-designed and prone to malfunction multi-mode conventional computer optic. Though excellent when it worked, the constant adjustments and poor battery-life drove soldiers mad, and led to its quick abandonment by mainline UNSCDF units."
 	icon_state = "ma3a"
 	item_state = "ma5c"
 	caliber = "7.62x51mm"
@@ -368,7 +370,7 @@
 
 /obj/item/weapon/gun/smg/halo/m7
 	name = "M7 submachine gun"
-	desc = "The M7 SMG is a relatively small caseless SMG that fires 5mm rounds. Coming with a folding stock and foldable grip, the M7 SMG has found its home in boarding action and special operations units for its compact size and low caliber."
+	desc = "Compact SMG in 5mm caseless. Collapsable stock, folding grip, just the ticket for a pocket hose. The M7 has found its home in boarding, protection detail, and special operations for its compact size and surprising stopping power."
 	icon_state = "m7"
 	item_state = "m7"
 	caliber = "5x23mm"
@@ -450,7 +452,7 @@
 
 /obj/item/weapon/gun/shotgun/pump/halo/m90
 	name = "\improper M90 CAWS"
-	desc = "Built and produced by Weapon System Technology, the M90 CAWS is a contemporary pump-action shotgun employed by the UNSC for CQC scenarios. It feeds twelve 8-gauge shotgun shells from it's internal tubular magazine."
+	desc = "Built and produced by Weapon System Technology, the M90 CAWS is a contemporary pump-action shotgun employed by the UNSCDF. It feeds twelve 8-gauge shotgun shells from internal tube with an iconic top-loading system."
 	icon_state = "m90"
 	item_state = "m90"
 	fire_sound = "gun_m90"

--- a/code/modules/projectiles/guns/halo/unsc_guns.dm
+++ b/code/modules/projectiles/guns/halo/unsc_guns.dm
@@ -14,7 +14,7 @@
 
 /obj/item/weapon/gun/rifle/halo/ma5c
 	name = "MA5C ICWS assault rifle"
-	desc = "The MA5C Misriah Armory Individual Combat Weapons System is a 7.62x51mm bullpup, integrating an electronic round counter, HUD link, and a slew of improvements from the B-variant. Most notable is a reduced 1:7 twist rate offering higher accuracy, reworked contact surfaces for stability in automatic fire, and a completely redesigned 32 round high reliability magazine. As an unintended benefit, the new mechanism and slower twist has actually resulted in a slightly higher muzzle velocity."
+	desc = "The MA5C Misriah Armory Individual Combat Weapons System is a 7.62x51mm bullpup, integrating an electronic round counter, HUD link, and a slew of improvements from the B-variant. Most notable is a reduced 1:7 twist rate offering higher accuracy, reworked contact surfaces for stability in automatic fire, and a completely redesigned 48 round high reliability magazine. As an unintended benefit, the new mechanism and slower twist has actually resulted in a slightly higher muzzle velocity."
 	icon_state = "ma5c"
 	item_state = "ma5c"
 	caliber = "7.62x51mm"
@@ -417,7 +417,8 @@
 	fa_max_scatter = 3
 
 /obj/item/weapon/gun/smg/halo/m7/socom
-	name = "M7 submachine gun"
+	name = "M7S submachine gun"
+	desc = "A silenced and accurized variant of the standard M7 SMG. Iconically used by the Orbital Drop Shock Troopers, though employed by other special mission units of the UNSC."
 	starting_attachment_types = list(
 		/obj/item/attachable/stock/m7,
 		/obj/item/attachable/stock/m7/grip/folded_down,
@@ -620,7 +621,7 @@
 
 /obj/item/weapon/gun/pistol/halo/m6c
 	name = "M6C service magnum"
-	desc = "The M6C is a semi-automatic 12.7x40mm recoil-operated handgun with a standard 12 round magazine. It's set apart from other M6 platform sidearms in that it does not come equipped with a smart-link scope attached to the top of it. Some marines reportedly prefer it due to the less cumbersome nature."
+	desc = "The M6C is a semi-automatic 12.7x40mm recoil-operated handgun with a standard 12 round magazine. Streamlining its profile, the standard scope is removed. Some marines reportedly prefer it for that reason."
 	icon_state = "m6c"
 	item_state = "m6"
 	caliber = "12.7x40mm"

--- a/code/modules/projectiles/guns/halo/unsc_guns.dm
+++ b/code/modules/projectiles/guns/halo/unsc_guns.dm
@@ -14,7 +14,7 @@
 
 /obj/item/weapon/gun/rifle/halo/ma5c
 	name = "MA5C ICWS assault rifle"
-	desc = "Belonging to the MA5 individual combat weapons system platform and produced by Misriah Armory, the MA5C is a staple weapon among the UNSC marine corps. It uses a box magazine capable of holding 32 7.62x51mm full-metal-jacket rounds."
+	desc = "The MA5C Misriah Armory Individual Combat Weapons System is a 7.62x51mm bullpup, integrating an electronic round counter, HUD link, and a slew of improvements from the B-variant. Most notable is a reduced 1:7 twist rate offering higher accuracy, reworked contact surfaces for stability in automatic fire, and a completely redesigned 32 round high reliability magazine. As an unintended benefit, the new mechanism and slower twist has actually resulted in a slightly higher muzzle velocity."
 	icon_state = "ma5c"
 	item_state = "ma5c"
 	caliber = "7.62x51mm"
@@ -70,8 +70,7 @@
 
 /obj/item/weapon/gun/rifle/halo/ma5b
 	name = "MA5B ICWS assault rifle"
-	desc = "The MA5B is an older member of the MA5 line produced by Misriah Armory, though still in use by the Marine Corps and Army. Fires a standard 7.62x51mm round in 60 round magazines, with superior firerate to the MA5C, though less stability and accuracy."
-	desc_lore = "While the MA5C was developed to meet many of the issues the UNSC Marine Corps found with the MA5B rifle, primarily its unreliable magazines and poor long-range performance, it remains popular among veterans and close quarter specialists. Especially when paired with 'shredder' ammunition."
+	desc = "The older weapon sports a torrential 900RPM cyclic rate backed by a deep 60 round magazine. Veterans and units expecting closer combat, for example in built up urban zones, often select the B-variant if at all possible. However, these two strengths would also drive its successor's adoption. While beloved by paper soldiers, the MA5B in automatic is vigorously unstable, and in semi its MOA is noticeably wider. Magazines must be taken care of carefully, or failures only a few hundred rounds in are almost certain."
 	icon_state = "ma5b"
 	item_state = "ma5b"
 	caliber = "7.62x51mm"
@@ -132,7 +131,7 @@
 
 /obj/item/weapon/gun/rifle/halo/ma3a
 	name = "MA3A assault rifle"
-	desc = "An old predecessor to the MA5 line, the MA3A had a notably short service history before being replaced by the more comprehensively designed MA5 series, nonetheless, enough were made to feed the private-security and would-be rebel markets for decades to come. Lacking the integrated combat suite of the MA5 rifles, the MA3A instead most commonly featured a over-designed and prone to malfunction multi-mode conventional computer optic. While robust in its capabilities, the constant adjustments and poor battery-life led to its quick abandonment by mainline UNSCDF units."
+	desc = "The MA5's predecessor had a notably short service history before being replaced by the more comprehensively designed MA5 series, though surplus from its large production run would often crop up in private security or rebel hands. Lacking the integrated combat suite of the MA5 rifles, the MA3A instead most commonly featured a over-designed and prone to malfunction multi-mode conventional computer optic. While robust in its capabilities, the constant adjustments and poor battery-life led to its quick abandonment by mainline UNSCDF units."
 	icon_state = "ma3a"
 	item_state = "ma5c"
 	caliber = "7.62x51mm"
@@ -188,7 +187,7 @@
 
 /obj/item/weapon/gun/rifle/halo/vk78
 	name = "VK78 surplus rifle"
-	desc = "The Colonial-Military-Authorities replacement for the ageing HMG-38, this 6.5x48mm rifle spent more of its life-time shooting targets than it had any combatant. Benefiting from a more ergonomically conventional layout, and exceptional mechanical simplicity, the Vk78 has long survived the CMA's downfall in the hands of militia-men, criminals, homesteaders and rebels alike. Listen for that distinct bark on patrol, it's probably not friendly."
+	desc = "The Colonial Military Authority's replacement for the aging HMG-38, this 6.5x48mm rifle spent more of its lifetime shooting targets than it had any combatant. Its rugged action and conventional layout has seen this weapon outlive the CMA, going on to arm militia, criminals, and sometimes homesteaders. Listen for that distinct bark on patrol, it's probably not friendly."
 	icon_state = "vk78"
 	item_state = "vk78"
 	caliber = "6.5x48mm"
@@ -247,7 +246,7 @@
 
 /obj/item/weapon/gun/rifle/halo/br55
 	name = "BR55 battle rifle"
-	desc = "A standard-issue marksman rifle in use by the UNSC Marine Corps, the BR55 battle rifle has a reasonably high power, acceptable rate of fire, and high accuracy. It comes with a standard 36-round detachable box magazine of 9.5x40mm experimental HP-SAP-HE rounds, allowing it to reach higher velocities than the MA5 series despite the smaller propellant."
+	desc = "The UNSC Marine Corps' new DMR. Noticeably more powerful than the MA5, a novel rifling scheme offers excellent accuracy and precision over any range. Standard issue mag is a 36 rounder of 9.5x40mm HP-SAP-HE, using new propellants and a very high chamber pressure for much improved muzzle velocity compared to the MA5 series."
 	icon_state = "br55"
 	item_state = "br55"
 	caliber = "9.5x40mm"
@@ -502,7 +501,7 @@
 
 /obj/item/weapon/gun/rifle/sniper/halo
 	name = "SRS99-AM sniper rifle"
-	desc = "The SRS99-AM sniper rifle is the standard issue sniper rifle across all branches of the UNSC due to it's extreme capabilities. It has a 4 round detachable box magazine of 14.5x114mm APFSDS ammunition and modularity allowing the entire barrel system to be removed and replaced with alternative variants."
+	desc = "The SRS99-AM sniper rifle is the UNSCDF's new standard issue sniper rifle. Feeds a 4 round mag of 14.5x114mm APFSDS with incredible performance at extreme range. One quirk of the weapon is a significant level of modularity, particularly in the barrel which may be replaced quickly or swapped entirely."
 	icon = 'icons/halo/obj/items/weapons/guns_by_faction/unsc/unsc_weapons.dmi'
 	icon_state = "srs99"
 	item_state = "srs99"
@@ -719,8 +718,7 @@
 
 /obj/item/weapon/gun/pistol/halo/m6d
 	name = "M6D service magnum"
-	desc = "The M6D service magnum is a high-power sidearm in use by the UNSC, particularly with officers and some special forces troops. Fires 12.7x40mm Semi-Armour-Piercing-High-Explosive (SAPHE) rounds out of a 12 round magazine."
-	desc_lore = "Its extended magazine and custom grip give it a striking profile which many consider unwieldy and bulky, though others will swear on the weapons power and accuracy with its integrated KFA-2 scope."
+	desc = "The D-variant of the M6 family. Integrating the KFA-2 scope alongside a new grip style, it is controllable and accurate at range. 12.7x40mm Semi-Armour-Piercing-High-Explosive (SAPHE) rounds out of a 12 round magazine grant crushing firepower. However, not all changes are welcomed, and some users swear the added bulk makes it unacceptably unwieldy."
 	icon_state = "m6d"
 	item_state = "m6"
 	caliber = "12.7x40mm"
@@ -786,7 +784,7 @@
 
 /obj/item/explosive/grenade/high_explosive/m15/unsc
 	name = "M9 fragmentation grenade"
-	desc = "A high explosive fragmentation grenade utilized by the UNSC."
+	desc = "The UNSCDF's standard issue frag grenade. 190 gram Composition L filler reliably saturates a 15 meter radius with fragments."
 	desc_lore = "Rumors spread about how every new posting someone gets, the design of the M9 fragmentation grenade looks different from the last ones they held."
 	icon = 'icons/halo/obj/items/weapons/grenades.dmi'
 	icon_state = "m9"

--- a/code/modules/projectiles/guns/halo/unsc_guns.dm
+++ b/code/modules/projectiles/guns/halo/unsc_guns.dm
@@ -70,7 +70,7 @@
 
 /obj/item/weapon/gun/rifle/halo/ma5b
 	name = "MA5B ICWS assault rifle"
-	desc = "The older weapon sports a torrential 900RPM cyclic rate backed by a deep 60 round magazine. Veterans and units expecting closer combat, for example in built up urban zones, often select the B-variant if at all possible. However, these two strengths would also drive its successor's adoption. While beloved by paper soldiers, the MA5B in automatic is vigorously unstable, and in semi its MOA is noticeably wider. Magazines must be taken care of carefully, or failures only a few hundred rounds in are almost certain."
+	desc = "The older weapon sports a torrential 900RPM cyclic backed by 60 round magazine. Veterans and units expecting closer combat often select the B-variant if at all possible. However, these strengths would drive its successor's adoption. While beloved by paper soldiers, it is violently unstable in automatic, and in semi its MOA wider. Magazines must be cared for carefully, or failures a few hundred rounds in are almost certain."
 	icon_state = "ma5b"
 	item_state = "ma5b"
 	caliber = "7.62x51mm"
@@ -418,7 +418,6 @@
 
 /obj/item/weapon/gun/smg/halo/m7/socom
 	name = "M7S submachine gun"
-	desc = "A silenced and accurized variant of the standard M7 SMG. Iconically used by the Orbital Drop Shock Troopers, though employed by other special mission units of the UNSC."
 	starting_attachment_types = list(
 		/obj/item/attachable/stock/m7,
 		/obj/item/attachable/stock/m7/grip/folded_down,
@@ -621,7 +620,7 @@
 
 /obj/item/weapon/gun/pistol/halo/m6c
 	name = "M6C service magnum"
-	desc = "The M6C is a semi-automatic 12.7x40mm recoil-operated handgun with a standard 12 round magazine. Streamlining its profile, the standard scope is removed. Some marines reportedly prefer it for that reason."
+	desc = "Semi-automatic 12.7x40mm recoil-operated pistol. Feed mechanism and grip has been redesigned, attempting to remedy the breakage problem alongside reliability faults. Its 'pugnose' design offers superior use in close quarters, but also incomplete powder burn resulting in lower performance than expected."
 	icon_state = "m6c"
 	item_state = "m6"
 	caliber = "12.7x40mm"
@@ -670,7 +669,7 @@
 
 /obj/item/weapon/gun/pistol/halo/m6c/m4a
 	name = "M4A pistol"
-	desc = "An antiquated 12.7x40mm pistol, popular among civilians and criminals alike. The M4A is a predecessor to the more commonly recognized M6 series of pistols by Misriah, removed from official service in 2414 when the M6 took stage.  It's regarded as being inaccurate with a blinding muzzle flash and deafening report, making it unsuited for most practical purposes, features that make it even more attractive to its most common users."
+	desc = "Vintage 12.7x40mm pistol, popular among civilians and criminals alike. Predecessor to the more commonly recognized M6 series, officially replaced in 2414. Common complaints were its inaccuracy, followed by a blinding, dirty muzzle flash and deafening report. These attributes would also be what gave it a second life among its new users."
 	icon_state = "m4a"
 	current_mag = /obj/item/ammo_magazine/pistol/halo/m6c
 	attachable_allowed = list(/obj/item/attachable/flashlight/m6)
@@ -693,7 +692,7 @@
 
 /obj/item/weapon/gun/pistol/halo/m6g
 	name = "M6G service magnum"
-	desc = "The M6G service magnum is a high-power sidearm utilized by the UNSC, using 12.7x40mm rounds held in a 8 round magazine. With a longer barrel, the M6G is more accurate and has a higher velocity than the M6C."
+	desc = "With a longer barrel and polygonal rifling, the M6G is more accurate and has a higher velocity. Capacity reverted to 8 rounds in a bid to reduce size of weapon and ammo, unfortunately also making it no longer backwards compatible."
 	icon_state = "m6g"
 	item_state = "m6"
 	caliber = "12.7x40mm"
@@ -719,7 +718,7 @@
 
 /obj/item/weapon/gun/pistol/halo/m6d
 	name = "M6D service magnum"
-	desc = "The D-variant of the M6 family. Integrating the KFA-2 scope alongside a new grip style, it is controllable and accurate at range. 12.7x40mm Semi-Armour-Piercing-High-Explosive (SAPHE) rounds out of a 12 round magazine grant crushing firepower. However, not all changes are welcomed, and some users swear the added bulk makes it unacceptably unwieldy."
+	desc = "The D-variant has a sterling reputation as a powerful and accurate weapon. To some with its integrated KFA-2 low power smart-link sight, in built up urban centers it's even a fine alternative to a sniper rifle. However, not all that glitters is gold, with some users swearing the added bulk makes it unacceptably unwieldy."
 	icon_state = "m6d"
 	item_state = "m6"
 	caliber = "12.7x40mm"
@@ -732,6 +731,7 @@
 	empty_click = 'sound/weapons/halo/m6d/gun_m6d_dryfire.ogg'
 
 /obj/item/weapon/gun/pistol/halo/m6g/unloaded
+//voibs. wrong magnum.
 	current_mag = null
 
 /obj/item/weapon/gun/pistol/halo/m6d/set_gun_attachment_offsets()
@@ -757,7 +757,7 @@
 
 /obj/item/weapon/gun/pistol/halo/m6a
 	name = "M6A service magnum"
-	desc = "The M6A is a semi-automatic 12.7x40mm recoil-operated handgun with a standard 12 round magazine. This variation is often given out to security and law enforcement firms as a more compact version of the standard template, though with less stopping power."
+	desc = "Phased-out member of the M6 family. Unique to the A-variant action is a recoil absorbing design, but velocity loss and accuracy issues were endemic until its replacement. Now seen in security and law enforcement use as a more compact, comfortable carry."
 	icon_state = "m6a"
 	item_state = "m6"
 	caliber = "12.7x40mm"

--- a/code/modules/projectiles/guns/halo/unsc_magazines.dm
+++ b/code/modules/projectiles/guns/halo/unsc_magazines.dm
@@ -9,7 +9,7 @@
 
 /obj/item/ammo_magazine/rifle/halo/ma5c
 	name = "\improper MA5C magazine (7.62x51mm FMJ)"
-	desc = "A rectangular box magazine for the MA5C holding 48 rounds of 7.62x51 FMJ ammunitions."
+	desc = "A rectangular box magazine for the MA5C holding 48 rounds of 7.62x51 FMJ."
 	icon_state = "ma5c"
 	max_rounds = 48
 	gun_type = /obj/item/weapon/gun/rifle/halo/ma5c
@@ -29,7 +29,7 @@
 
 /obj/item/ammo_magazine/rifle/halo/ma5b
 	name = "\improper MA5B magazine (7.62x51mm FMJ)"
-	desc = "A rectangular box magazine for the MA5C holding 60 rounds of 7.62x51 FMJ ammunitions."
+	desc = "A rectangular box magazine for the MA5C holding 60 rounds of 7.62x51 FMJ. Feed lips and spring are the most common points of failure, take care of this magazine!"
 	icon_state = "ma5b"
 	max_rounds = 60
 	gun_type = /obj/item/weapon/gun/rifle/halo/ma5b
@@ -40,7 +40,7 @@
 
 /obj/item/ammo_magazine/rifle/halo/ma5b/shredder
 	name = "\improper MA5B magazine (7.62x51mm Shredder)"
-	desc = "A rectangular box magazine for the MA5B holding 60 rounds of 7.62x51 shredder ammunitions, a specialized ammunition that pierces armor and splinters in the target."
+	desc = "A rectangular box magazine for the MA5B holding 60 rounds of 7.62x51 shredder, a specialized round that pierces armor with violent behind-armor effect. Feed lips and spring are the most common points of failure, take care of this magazine!"
 	max_rounds = 60
 	gun_type = /obj/item/weapon/gun/rifle/halo/ma5b
 	default_ammo = /datum/ammo/bullet/rifle/ma5/shredder

--- a/code/modules/projectiles/guns/halo/unsc_magazines.dm
+++ b/code/modules/projectiles/guns/halo/unsc_magazines.dm
@@ -9,7 +9,7 @@
 
 /obj/item/ammo_magazine/rifle/halo/ma5c
 	name = "\improper MA5C magazine (7.62x51mm FMJ)"
-	desc = "A rectangular box magazine for the MA5C holding 48 rounds of 7.62x51 FMJ."
+	desc = "A magazine for the MA5C holding 48 rounds of 7.62x51 FMJ. M118 FMJ ammo offers reliable performance with limited barrier-blind and armor-piercing capability."
 	icon_state = "ma5c"
 	max_rounds = 48
 	gun_type = /obj/item/weapon/gun/rifle/halo/ma5c
@@ -20,7 +20,7 @@
 
 /obj/item/ammo_magazine/rifle/halo/ma5c/shredder
 	name = "\improper MA5C magazine (7.62x51mm Shredder)"
-	desc = "A rectangular box magazine for the MA5C holding 48 rounds of 7.62x51 shredder ammunitions, a specialized ammunition that pierces armor and splinters in the target."
+	desc = "A magazine for the MA5C holding 48 rounds of 7.62x51 shredder, a specialized round that pierces armor with violent behind-armor effect."
 	max_rounds = 48
 	gun_type = /obj/item/weapon/gun/rifle/halo/ma5c
 	default_ammo = /datum/ammo/bullet/rifle/ma5/shredder
@@ -29,7 +29,7 @@
 
 /obj/item/ammo_magazine/rifle/halo/ma5b
 	name = "\improper MA5B magazine (7.62x51mm FMJ)"
-	desc = "A rectangular box magazine for the MA5C holding 60 rounds of 7.62x51 FMJ. Feed lips and spring are the most common points of failure, take care of this magazine!"
+	desc = "A magazine for the MA5C holding 60 rounds of 7.62x51 FMJ. Feed lips and spring are the most common points of failure, take care of this magazine!"
 	icon_state = "ma5b"
 	max_rounds = 60
 	gun_type = /obj/item/weapon/gun/rifle/halo/ma5b
@@ -40,7 +40,7 @@
 
 /obj/item/ammo_magazine/rifle/halo/ma5b/shredder
 	name = "\improper MA5B magazine (7.62x51mm Shredder)"
-	desc = "A rectangular box magazine for the MA5B holding 60 rounds of 7.62x51 shredder, a specialized round that pierces armor with violent behind-armor effect. Feed lips and spring are the most common points of failure, take care of this magazine!"
+	desc = "A magazine for the MA5B holding 60 rounds of 7.62x51 shredder, a specialized round that pierces armor with violent behind-armor effect. Feed lips and spring are the most common points of failure, take care of this magazine!"
 	max_rounds = 60
 	gun_type = /obj/item/weapon/gun/rifle/halo/ma5b
 	default_ammo = /datum/ammo/bullet/rifle/ma5/shredder
@@ -49,7 +49,7 @@
 
 /obj/item/ammo_magazine/rifle/halo/ma3a
 	name = "\improper MA3A magazine (7.62x51mm FMJ)"
-	desc = "A rectangular box magazine for the MA3A holding 32 rounds of 7.62x51 FMJ ammunitions."
+	desc = "A magazine for the MA3A holding 32 rounds of 7.62x51 FMJ."
 	icon_state = "ma3a"
 	max_rounds = 32
 	gun_type = /obj/item/weapon/gun/rifle/halo/ma3a
@@ -58,7 +58,7 @@
 
 /obj/item/ammo_magazine/rifle/halo/vk78
 	name = "\improper VK78 magazine (6.5x48mm FMJ)"
-	desc = "An angular box magazine for the VK78 holding 20 rounds of 6.5x48mm FMJ ammunitions."
+	desc = "An angular box magazine for the VK78 holding 20 rounds of 6.5x48mm FMJ."
 	icon_state = "vk78"
 	max_rounds = 20
 	gun_type = /obj/item/weapon/gun/rifle/halo/vk78
@@ -67,7 +67,7 @@
 
 /obj/item/ammo_magazine/rifle/halo/br55
 	name = "\improper BR55 magazine (9.5x40mm X-HP SAP-HE)"
-	desc = "A rectangular box magazine for the BR55 holding 36 rounds of 9.5x40mm X-HP SAP-HE ammunitions."
+	desc = "A magazine for the BR55 holding 36 rounds of 9.5x40mm X-HP SAP-HE."
 	icon_state = "br55"
 	max_rounds = 36
 	gun_type = /obj/item/weapon/gun/rifle/halo/br55
@@ -77,14 +77,14 @@
 
 /obj/item/ammo_magazine/rifle/halo/br55/extended
 	name = "\improper quad-stack BR55 magazine (9.5x40mm X-HP SAP-HE)"
-	desc = "A quad-stack rectangular box magazine for the BR55 holding 60 rounds of 9.5x40mm X-HP SAP-HE ammunitions."
+	desc = "A quad-stack magazine for the BR55 holding 60 rounds of 9.5x40mm X-HP SAP-HE."
 	icon_state = "br55_quadstack"
 	max_rounds = 60
 	bonus_overlay = "br55_ext_overlay"
 
 /obj/item/ammo_magazine/rifle/halo/dmr
 	name = "\improper M392 DMR magazine (7.62x51mm FMJ)"
-	desc = "A rectangular 15 round box magazine for the M392 DMR filled with 7.62x51mm FMJ ammo."
+	desc = "A rectangular 15 round box magazine for the M392 DMR filled with 7.62x51mm FMJ."
 	icon_state = "dmr"
 	max_rounds = 15
 	gun_type = /obj/item/weapon/gun/rifle/halo/dmr
@@ -112,7 +112,7 @@
 
 /obj/item/ammo_magazine/rifle/halo/sniper
 	name = "\improper SRS99-AM magazine (14.5x114mm APFSDS)"
-	desc = "A rectangular box magazine for the SRS99-AM holding four rounds of 14.5x114mm armor-piercing, fin-stabilized, discarding sabot."
+	desc = "A magazine for the SRS99-AM holding four rounds of 14.5x114mm armor-piercing, fin-stabilized, discarding sabot."
 	icon_state = "srs99"
 	max_rounds = 4
 	gun_type = /obj/item/weapon/gun/rifle/sniper/halo
@@ -159,7 +159,7 @@
 
 /obj/item/ammo_magazine/spnkr
 	name = "\improper M19 SSM tube assembly"
-	desc = "A 102mm dual-tubed rocket assembly intended to be loaded into an M41 spnkr."
+	desc = "A 102mm dual-tubed rocket assembly intended to be loaded into an M41 SPNKR."
 	caliber = "102mm"
 	icon = 'icons/halo/obj/items/weapons/guns_by_faction/unsc/special.dmi'
 	icon_state = "spnkr_rockets"
@@ -173,7 +173,7 @@
 	..()
 	if(current_rounds <= 0)
 		name = "\improper spent M19 SSM tube assembly"
-		desc = "A spent 102mm dual-tubed rocket assembly previously loaded into a spnkr. Of no use to you now..."
+		desc = "A spent 102mm dual-tubed rocket assembly previously loaded into a SPNKR. Of no use to you now..."
 
 /obj/item/ammo_magazine/spnkr/attack(mob/living/carbon/human/carbon, mob/living/carbon/human/user)
 	if(!istype(carbon) || !istype(user) || get_dist(user, carbon) > 1)
@@ -235,7 +235,7 @@
 
 /obj/item/ammo_magazine/pistol/halo/m6c
 	name = "\improper M6C magazine (12.7x40mm SAP-HE)"
-	desc = "A rectangular and slanted magazine for the M6C, holding 12 rounds of 12.7x40mm SAP-HE ammunition."
+	desc = "A rectangular and slanted magazine for the M6C, holding 12 rounds of 12.7x40mm SAP-HE."
 	icon_state = "m6c"
 	gun_type = /obj/item/weapon/gun/pistol/halo/m6c
 	default_ammo = /datum/ammo/bullet/pistol/magnum
@@ -251,7 +251,7 @@
 
 /obj/item/ammo_magazine/pistol/halo/m6a
 	name = "\improper M6A magazine (12.7x40mm SAP-HE)"
-	desc = "A rectangular and slanted magazine for the M6A, holding 12 rounds of 12.7x40mm SAP-HE ammunition."
+	desc = "A rectangular and slanted magazine for the M6A, holding 12 rounds of 12.7x40mm SAP-HE."
 	icon_state = "m6c"
 	gun_type = /obj/item/weapon/gun/pistol/halo/m6a
 	default_ammo = /datum/ammo/bullet/pistol/magnum
@@ -259,7 +259,7 @@
 
 /obj/item/ammo_magazine/pistol/halo/m6g
 	name = "\improper M6G magazine (12.7x40mm SAP-HE)"
-	desc = "A rectangular slanted magazine for the M6G, holding 8 rounds of 12.7x40mm SAP-HE ammunition."
+	desc = "A rectangular slanted magazine for the M6G, holding 8 rounds of 12.7x40mm SAP-HE."
 	icon_state = "m6g"
 	gun_type = /obj/item/weapon/gun/pistol/halo/m6g
 	default_ammo = /datum/ammo/bullet/pistol/magnum
@@ -267,7 +267,7 @@
 
 /obj/item/ammo_magazine/pistol/halo/m6d
 	name = "\improper M6D magazine (12.7x40mm SAP-HE)"
-	desc = "A rectangular slanted magazine for the M6D, holding 12 rounds of 12.7x40mm SAP-HE ammunition. Chrome finish."
+	desc = "A rectangular slanted magazine for the M6D, holding 12 rounds of 12.7x40mm SAP-HE. Chrome finish."
 	icon_state = "m6d"
 	gun_type = /obj/item/weapon/gun/pistol/halo/m6d
 	default_ammo = /datum/ammo/bullet/pistol/magnum


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Removes some CMPVE legacy descriptions, adds new ones in other places. Corrects a few typos.

# Explain why it's good for the game

Zero risk improvement :thumbsup:

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
 
:cl:
add: New MA5B, MA5C, MA3A, BR55, SR99AM, M6C, M6D description
add: Tweaked MA5B, MA5C magazine descriptions.
del: MA5B extended lore, M6D extended lore
spellcheck: VK78 description reworked, couple typos fixed.
add: M7/socom is now named M7S.
add: Additional M52B armor description
add: New M52B, Police, ODST armor attachments descriptions and name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
