### PR TITLE
RTO & ODST SL fixes

### DIFF
--- a/code/datums/factions/unsc.dm
+++ b/code/datums/factions/unsc.dm
@@ -14,6 +14,7 @@
 		else if(I)
 			_role = I.rank
 		switch(GET_DEFAULT_ROLE(_role))
+			if(JOB_SQUAD_LEADER) marine_rk = "leader"
 			if(JOB_SQUAD_ENGI) marine_rk = "engi"
 			if(JOB_SQUAD_SPECIALIST) marine_rk = "spec"
 			if(JOB_SQUAD_TEAM_LEADER) marine_rk = "tl"
@@ -222,6 +223,8 @@
 				marine_rk = "tl"
 			if(JOB_SQUAD_LEADER)
 				marine_rk = "leader"
+			if(JOB_SQUAD_RTO)
+				marine_rk = "rto"
 
 		if(marine_rk)
 			var/image/I = image('icons/mob/hud/marine_hud.dmi', current_human, "hudsquad")

--- a/code/game/jobs/job/marine/squad/standard.dm
+++ b/code/game/jobs/job/marine/squad/standard.dm
@@ -103,7 +103,7 @@
 	job_options = list(PFC_VARIANT = "PFC", LCPL_VARIANT = "LCPL")
 
 /datum/job/marine/standard/ai/rto/handle_job_options(option)
-	if(option != PFC_VARIANT)
+	if(option != LCPL_VARIANT)
 		gear_preset = gear_preset_secondary
 	else
 		gear_preset = initial(gear_preset)


### PR DESCRIPTION

# About the pull request

Fixes ODST RTO rank selections
Fixes missing ODST SL HUD icon
Fixes missing regular RTO HUD icon, addresses #147 

# Explain why it's good for the game

Bug fixes good


# Testing Photographs and Procedure
Tested locally, all working

# Changelog

:cl:
fix: ODST RTO rank selections correspond to correct rank
fix: ODST SL now has HUD icon
fix: Regular marine RTO has HUD icon
/:cl:

