### PR TITLE
Fixes #109 (ODST RFN rank mismatch) & #130 (M7 SMG producing cases)

### DIFF
--- a/code/datums/ammo/bullet/halo_unsc_ammo.dm
+++ b/code/datums/ammo/bullet/halo_unsc_ammo.dm
@@ -82,6 +82,7 @@
 	penetration = ARMOR_PENETRATION_TIER_1
 	scatter = SCATTER_AMOUNT_TIER_8
 	accuracy = HIT_ACCURACY_TIER_4
+	shell_casing = null
 
 // shotgun ammo
 

--- a/code/game/jobs/job/marine/squad/standard.dm
+++ b/code/game/jobs/job/marine/squad/standard.dm
@@ -65,7 +65,7 @@
 	title = JOB_SQUAD_MARINE_ODST
 	gear_preset = /datum/equipment_preset/unsc/pfc/odst
 	gear_preset_secondary = /datum/equipment_preset/unsc/pfc/odst/lesser_rank
-	job_options = list(PFC_VARIANT = "LCPL", PVT_VARIANT = "PFC")
+	job_options = list(PFC_VARIANT = "PFC", LCPL_VARIANT = "LCPL")
 
 /datum/job/marine/standard/ai/upp
 	title = JOB_SQUAD_MARINE_UPP

--- a/code/modules/projectiles/guns/halo/unsc_guns.dm
+++ b/code/modules/projectiles/guns/halo/unsc_guns.dm
@@ -381,7 +381,7 @@
 	empty_sound = null
 	w_class = SIZE_LARGE
 
-	flags_gun_features = GUN_AUTO_EJECT_CASINGS|GUN_CAN_POINTBLANK
+	flags_gun_features = GUN_CAN_POINTBLANK
 	start_automatic = TRUE
 	map_specific_decoration = FALSE
 	current_mag = /obj/item/ammo_magazine/smg/halo/m7


### PR DESCRIPTION
# About the pull request

M7 ammo is properly caseless now as per the lore
ODST RFN rank selections are now correct, didn't realise they were borked too when I was fixing the RTO ones

# Explain why it's good for the game

Lore compliant SMG, less weirdness with ranks on the player-facing side of things. Bugfixing is always good too
Fixes #130
Fixes #109

# Testing Photographs and Procedure

Tested on local, working as expected

# Changelog

:cl:
fix: M7 & M7S SMGs now properly use caseless ammo
fix: ODST RFN rank options now correspond to the correct rank
/:cl:
