### PR TITLE
Fix upstream url for mapmerge

### DIFF
--- a/tools/mapmerge2/fixup.py
+++ b/tools/mapmerge2/fixup.py
@@ -60,7 +60,7 @@ def main(repo : pygit2.Repository):
 
     # Set up upstream remote if needed
     try:
-        repo.remotes.create("upstream", "https://github.com/cmss13-devs/cmss13-pve.git")
+        repo.remotes.create("upstream", "https://github.com/cmss13-devs/cmss13-pve-halo.git")
     except ValueError:
         pass
     else:


### PR DESCRIPTION

# About the pull request

This PR simply corrects the incorrect git url that adds `upstream` if it doesn't already exist when running the mapmerge fixup script.

Be sure to check your `upstream` url and correct it if needed e.g. `git remote set-url upstream https://github.com/cmss13-devs/cmss13-pve-halo.git`

# Changelog

No player facing changes.
