### PR TITLE
Medical Update - Field medkit vs wall medkit

### DIFF
--- a/code/game/machinery/vending/vendor_types/halo/misc.dm
+++ b/code/game/machinery/vending/vendor_types/halo/misc.dm
@@ -41,7 +41,7 @@
 	listed_products = list(
 		list("ESSENTIAL SUPPLIES", -1, null, null),
 		list("Syringe", floor(scale * 7), /obj/item/reagent_container/syringe/halo, VENDOR_ITEM_MANDATORY),
-		list("Empty Medkit", floor(scale * 1), /obj/item/storage/firstaid/unsc/empty, VENDOR_ITEM_REGULAR),
+		list("Empty Medkit", floor(scale * 1), /obj/item/storage/firstaid/unsc/field/empty, VENDOR_ITEM_REGULAR),
 		list("Syringe Case", floor(scale * 2), /obj/item/storage/syringe_case/unsc, VENDOR_ITEM_REGULAR),
 
 		list("FIELD SUPPLIES", -1, null, null),

--- a/code/game/machinery/vending/vendor_types/squad_prep/halo/unsc_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/halo/unsc_prep.dm
@@ -300,8 +300,8 @@ GLOBAL_LIST_INIT(cm_vending_clothing_medic_unsc, list(
 
 /obj/effect/essentials_set/medic/unsc
 	spawned_gear_list = list(
-		/obj/item/storage/firstaid/unsc/corpsman,
-		/obj/item/storage/firstaid/unsc/corpsman,
+		/obj/item/storage/firstaid/unsc/field/corpsman,
+		/obj/item/storage/firstaid/unsc/field/corpsman,
 		/obj/item/device/healthanalyzer/halo,
 		/obj/item/tool/surgery/surgical_line,
 		/obj/item/tool/surgery/synthgraft,

--- a/code/game/objects/items/storage/halo/firstaid.dm
+++ b/code/game/objects/items/storage/halo/firstaid.dm
@@ -10,7 +10,7 @@
 	maptext_width = 32
 	maptext_x = 18
 	maptext_y = 3
-	w_class = SIZE_MEDIUM
+	w_class = SIZE_LARGE
 	var/maptext_label
 	var/display_maptext = TRUE
 
@@ -74,6 +74,40 @@
 /obj/item/storage/firstaid/unsc/empty
 
 /obj/item/storage/firstaid/unsc/empty/fill_preset_inventory()
+	return
+
+/obj/item/storage/firstaid/unsc/field
+	name = "UNSC health field pack"
+	desc = "First-class military medical aid is typically found in these octogon-shaped health packs. This one is specifically designed for field use, with a corpsman in mind."
+	w_class = SIZE_MEDIUM
+
+/obj/item/storage/firstaid/unsc/field/fill_preset_inventory()
+	new /obj/item/device/healthanalyzer/halo(src)
+	new /obj/item/stack/medical/bruise_pack(src)
+	new /obj/item/stack/medical/bruise_pack(src)
+	new /obj/item/stack/medical/bruise_pack(src)
+	new /obj/item/stack/medical/advanced/ointment(src)
+	new /obj/item/stack/medical/advanced/ointment(src)
+	new /obj/item/stack/medical/splint(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/primeable/biofoam/small(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/bicaridine/halo(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/primeable/burnguard(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/tramadol/halo(src)
+
+/obj/item/storage/firstaid/unsc/field/corpsman/fill_preset_inventory()
+	new /obj/item/stack/medical/advanced/bruise_pack(src)
+	new /obj/item/stack/medical/advanced/bruise_pack(src)
+	new /obj/item/stack/medical/advanced/bruise_pack(src)
+	new /obj/item/stack/medical/advanced/ointment(src)
+	new /obj/item/stack/medical/advanced/ointment(src)
+	new /obj/item/stack/medical/advanced/ointment(src)
+	new /obj/item/stack/medical/splint(src)
+	new /obj/item/reagent_container/blood/OMinus(src)
+	new /obj/item/reagent_container/blood/OMinus(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/primeable/biofoam(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/primeable/biofoam(src)
+
+/obj/item/storage/firstaid/unsc/field/empty/fill_preset_inventory()
 	return
 
 /obj/item/storage/syringe_case/unsc


### PR DESCRIPTION
# About the pull request

WAS ORIGINALLY PART OF #156 BUT I WAS YELLED AT 

Made a new subtype of the medkit, a Field medkit. Now the wall medkits are too big to be put in bags but the field medkits are issued to corpsman and can still fit in backpacks

edited some vendors accordingly

# Explain why it's good for the game

massive medkit in your backpack makes little sense, the IFAK kits are cooler. But we don't penalise the corpsman players. 

# Testing Photographs and Procedure
it was part of the bigger PR for ages and was fine

# Changelog

:cl:
add: subtype of medkits, field medkits. Regular medkits increase in size, field medkits remain medium size. Fixed all relevant vendors/item packages related to this 
/:cl:

