### PR TITLE
Randomised & expanded End-Of-Round facts

### DIFF
--- a/code/datums/statistics/entities/death_stats.dm
+++ b/code/datums/statistics/entities/death_stats.dm
@@ -14,7 +14,7 @@
 	var/cause_role_name
 	var/cause_faction_name
 
-	var/total_steps = 0
+	var/total_steps
 	var/total_kills = 0
 	var/time_of_death
 	var/total_time_alive

--- a/code/datums/statistics/random_facts/christmas_fact.dm
+++ b/code/datums/statistics/random_facts/christmas_fact.dm
@@ -1,17 +1,40 @@
-/datum/random_fact/christmas/announce()
+// Leaderboard stat for festivizer_hits_total_max
+// Normally includes dead always but can disable by setting prob_check_dead to 0
+
+/datum/random_fact/christmas
+	role_filter = null
+
+/datum/random_fact/christmas/life_grab_stat(mob/fact_mob)
+	return fact_mob.festivizer_hits_total
+
+/datum/random_fact/christmas/generate_announcement_message()
+	if(!check_xeno && !check_human)
+		return null
+
 	var/festivizer_hits_total_max = 0
 	var/mob/mob_to_report = null
 
 	var/list/list_to_check = list()
-	list_to_check += GLOB.living_mob_list
-	list_to_check += GLOB.dead_mob_list
-	for(var/mob/checked_mob as anything in list_to_check)
-		if(festivizer_hits_total_max < checked_mob.festivizer_hits_total)
-			mob_to_report = checked_mob
-			festivizer_hits_total_max = checked_mob.festivizer_hits_total
+	if(check_human)
+		if(prob_check_dead > 0)
+			list_to_check += GLOB.human_mob_list
+		else
+			list_to_check += GLOB.alive_human_list
+	if(check_xeno)
+		if(prob_check_dead > 0)
+			list_to_check += GLOB.xeno_mob_list
+		else
+			list_to_check += GLOB.living_xeno_list
 
-	if(!mob_to_report || !festivizer_hits_total_max)
-		return
+	for(var/mob/checked_mob as anything in list_to_check)
+		if(check_mob_ignored(checked_mob))
+			continue
+		if(festivizer_hits_total_max < checked_mob.festivizer_hits_total && (checked_mob.persistent_ckey in GLOB.directory))
+			mob_to_report = checked_mob
+			festivizer_hits_total_max = life_grab_stat(checked_mob)
+
+	if(!mob_to_report || festivizer_hits_total_max < min_required)
+		return null
 
 	var/name = mob_to_report.real_name
 	var/additional_message
@@ -27,6 +50,4 @@
 		else
 			additional_message = "<b>[name] is the VERY SPIRIT of CHRISTMAS!!!</b>"
 
-	message = "<b>[name]</b> festivized a grand total of <b>[festivizer_hits_total_max] objects!</b> [additional_message]"
-
-	return ..()
+	return "<b>[name]</b> festivized a grand total of <b>[festivizer_hits_total_max] objects!</b> [additional_message]"

--- a/code/datums/statistics/random_facts/damage_fact.dm
+++ b/code/datums/statistics/random_facts/damage_fact.dm
@@ -1,6 +1,7 @@
 /datum/random_fact/damage
 	statistic_name = "damage"
 	statistic_verb = "took"
+	min_required = 400
 
 /datum/random_fact/damage/life_grab_stat(mob/fact_mob)
 	return fact_mob.life_damage_taken_total

--- a/code/datums/statistics/random_facts/ib_fact.dm
+++ b/code/datums/statistics/random_facts/ib_fact.dm
@@ -1,6 +1,7 @@
 /datum/random_fact/ib
 	statistic_name = "people"
 	statistic_verb = "fixed internal bleeding for"
+	min_required = 3
 
 /datum/random_fact/ib/life_grab_stat(mob/fact_mob)
 	return fact_mob.life_ib_total

--- a/code/datums/statistics/random_facts/kills_fact.dm
+++ b/code/datums/statistics/random_facts/kills_fact.dm
@@ -1,6 +1,9 @@
 /datum/random_fact/kills
 	statistic_name = "kills"
 	statistic_verb = "earned"
+	role_filter = list(XENO_CASTE_FACEHUGGER, XENO_CASTE_LESSER_DRONE, XENO_CASTE_LARVA, XENO_CASTE_PREDALIEN_LARVA)
+	role_filter_blacklist = TRUE
+	min_required = 5
 
 /datum/random_fact/kills/life_grab_stat(mob/fact_mob)
 	return fact_mob.life_kills_total

--- a/code/datums/statistics/random_facts/random_fact.dm
+++ b/code/datums/statistics/random_facts/random_fact.dm
@@ -1,86 +1,161 @@
+/// How many facts per faction (marine/xeno) to announce
+#define MAX_FACTION_FACTS_TO_ANNOUNCE 5
+
 /datum/random_fact
-	var/message = null
+	/// The noun for this statistic in the announcement
 	var/statistic_name = null
+	/// The verb for this statistic in the announcement
 	var/statistic_verb = null
-
+	/// Whether this statistic can apply to humans
 	var/check_human = TRUE
+	/// Whether this statistic can apply to xenos
 	var/check_xeno = TRUE
+	/// The prob dead are checked for this statistic
+	var/prob_check_dead = 50
+	/// The min stat required to be noted
+	var/min_required = 1
+	/// Any factions to filter for this statistic
+	var/list/faction_filter = list("Tutorial Hive")
+	/// Whether the faction_filter is a blacklist (otherwise whitelist)
+	var/list/faction_filter_blacklist = TRUE
+	/// Any roles to filter for this statistic
+	var/list/role_filter = list(XENO_CASTE_FACEHUGGER, XENO_CASTE_LESSER_DRONE)
+	/// Whether the role_filter is a blacklist (otherwise whitelist)
+	var/list/role_filter_blacklist = TRUE
 
-/datum/random_fact/New(set_check_human = TRUE, set_check_xeno = TRUE)
+/datum/random_fact/New(check_human=TRUE, check_xeno=TRUE)
 	. = ..()
-	check_human = set_check_human
-	check_xeno = set_check_xeno
+	src.check_human = initial(src.check_human) && check_human
+	src.check_xeno = initial(src.check_human) && check_xeno
 
+/// Announces this random_fact to world if possible (returns TRUE if sent)
 /datum/random_fact/proc/announce()
-	calculate_announcement_message()
+	var/message = generate_announcement_message()
 	if(message)
 		to_world(SPAN_CENTERBOLD(message))
 		return TRUE
 	return FALSE
 
-/datum/random_fact/proc/calculate_announcement_message()
-	var/death_stat_gotten = 0
-	var/living_stat_gotten = 0
-	var/datum/entity/statistic/death/death_to_report = null
-	var/mob/mob_to_report = null
+/// Returns TRUE if the provided datum/entity/statistic/death is ignored via faction/role filters
+/datum/random_fact/proc/check_death_ignored(datum/entity/statistic/death/entry)
+	if(entry.faction_name in faction_filter)
+		if(faction_filter_blacklist)
+			return TRUE
+	else if(!faction_filter_blacklist)
+		return TRUE
 
-	if(GLOB.round_statistics && length(GLOB.round_statistics.death_stats_list))
-		for(var/datum/entity/statistic/death/death in GLOB.round_statistics.death_stats_list)
-			if(!check_human && !death.is_xeno)
+	if(entry.role_name in role_filter)
+		if(role_filter_blacklist)
+			return TRUE
+	else if(!role_filter_blacklist)
+		return TRUE
+
+	return FALSE
+
+/// Returns TRUE if the provided mob is ignored via faction/role filters
+/datum/random_fact/proc/check_mob_ignored(mob/target)
+	if(target.faction in faction_filter)
+		if(faction_filter_blacklist)
+			return TRUE
+	else if(!faction_filter_blacklist)
+		return TRUE
+
+	if(target.get_role_name() in role_filter)
+		if(role_filter_blacklist)
+			return TRUE
+	else if(!role_filter_blacklist)
+		return TRUE
+
+	return FALSE
+
+/// Returns the /datum/entity/statistic/death for a random still connected player that has min_required for this stat
+/datum/random_fact/proc/find_death_to_report()
+	RETURN_TYPE(/datum/entity/statistic/death)
+
+	if(!GLOB.round_statistics)
+		return null
+	if(!length(GLOB.round_statistics.death_stats_list))
+		return null
+
+	var/list/list_to_check = shuffle(GLOB.round_statistics.death_stats_list)
+	for(var/datum/entity/statistic/death/death as anything in list_to_check)
+		if(death.is_xeno)
+			if(!check_xeno)
 				continue
-			if(!check_xeno && death.is_xeno)
+		else
+			if(!check_human)
 				continue
-			if(death_stat_gotten < death_grab_stat(death))
-				death_to_report = death
-				death_stat_gotten = death_grab_stat(death)
+		if(check_death_ignored(death))
+			continue
+		var/datum/entity/player/player_record = DB_ENTITY(/datum/entity/player, death.player_id)
+		if(!player_record)
+			debug_log("/datum/entity/player lookup failed for '[death.player_id]' during [type]'s find_death_to_report")
+			continue
+		if(!(player_record.ckey in GLOB.directory))
+			continue // Not connected anymore
+		if(death_grab_stat(death) >= min_required)
+			return death // Success
+
+/// Returns the /mob/living/carbon for a random still connected player that has min_required for this stat
+/datum/random_fact/proc/find_living_to_report()
+	RETURN_TYPE(/mob/living/carbon)
 
 	var/list/list_to_check = list()
 	if(check_human)
 		list_to_check += GLOB.alive_human_list
 	if(check_xeno)
 		list_to_check += GLOB.living_xeno_list
+	list_to_check = shuffle(list_to_check)
 
-	for(var/mob/checked_mob as anything in list_to_check)
-		if(!checked_mob?.persistent_ckey)
-			continue // We don't care about NPCs
-		if(living_stat_gotten < life_grab_stat(checked_mob))
-			mob_to_report = checked_mob
-			living_stat_gotten = life_grab_stat(checked_mob)
+	for(var/mob/living/carbon/checked_mob as anything in list_to_check)
+		if(check_mob_ignored(checked_mob))
+			continue
+		if(!(checked_mob.persistent_ckey in GLOB.directory))
+			continue // We don't care about NPCs or people disconnected
+		if(life_grab_stat(checked_mob) >= min_required)
+			return checked_mob // Success
+
+/// Attempts to get a statistic to report on and returns the string of the message otherwise null if no one met requirements
+/datum/random_fact/proc/generate_announcement_message()
+	if(!check_xeno && !check_human)
+		return null
+
+	var/datum/entity/statistic/death/death_to_report = null
+	var/mob/mob_to_report = null
+
+	var/dead_attempted = FALSE
+	if(prob(prob_check_dead))
+		dead_attempted = TRUE
+		death_to_report = find_death_to_report()
+	if(!death_to_report && prob_check_dead < 100)
+		mob_to_report = find_living_to_report()
+	if(!mob_to_report && prob_check_dead > 0 && !dead_attempted)
+		death_to_report = find_death_to_report()
 
 	if(!death_to_report && !mob_to_report)
-		return
+		return null
 
 	var/name = ""
 	var/stat_gotten = 0
 	var/additional_message = ""
-	if(death_to_report && mob_to_report)
-		if(living_stat_gotten > death_stat_gotten)
-			name = mob_to_report.real_name
-			stat_gotten = living_stat_gotten
-			additional_message = "and survived! Great work!"
-		else
-			name = death_to_report.mob_name
-			stat_gotten = death_stat_gotten
-			additional_message = "before dying"
-			if(death_to_report.cause_name)
-				additional_message += " to <b>[death_to_report.cause_name]</b>"
-			additional_message += ". Good work!"
-	else if(death_to_report)
+	if(death_to_report)
 		name = death_to_report.mob_name
-		stat_gotten = death_stat_gotten
+		stat_gotten = death_grab_stat(death_to_report)
 		additional_message = "before dying"
 		if(death_to_report.cause_name)
 			additional_message += " to <b>[death_to_report.cause_name]</b>"
 		additional_message += ". Good work!"
 	else
 		name = mob_to_report.real_name
-		stat_gotten = living_stat_gotten
+		stat_gotten = life_grab_stat(mob_to_report)
 		additional_message = "and survived! Great work!"
 
-	message = "<b>[name]</b> [statistic_verb] <b>[stat_gotten] [statistic_name]</b> [additional_message]"
+	return "<b>[name]</b> [statistic_verb] <b>[stat_gotten] [statistic_name]</b> [additional_message]"
 
+/// Override this to specify what value on a mob to get for this statistic
 /datum/random_fact/proc/life_grab_stat(mob/fact_mob)
 	return 0
 
+/// Override this to specify what value on a death to get for this statistic
 /datum/random_fact/proc/death_grab_stat(datum/entity/statistic/death/fact_death)
 	return 0

--- a/code/datums/statistics/random_facts/revives_fact.dm
+++ b/code/datums/statistics/random_facts/revives_fact.dm
@@ -1,6 +1,7 @@
 /datum/random_fact/revives
 	statistic_name = "people"
 	statistic_verb = "revived"
+	min_required = 5
 
 /datum/random_fact/revives/life_grab_stat(mob/fact_mob)
 	return fact_mob.life_revives_total

--- a/code/datums/statistics/random_facts/steps_facts.dm
+++ b/code/datums/statistics/random_facts/steps_facts.dm
@@ -1,0 +1,10 @@
+/datum/random_fact/steps
+	statistic_name = "calories"
+	statistic_verb = "burned"
+	min_required = 100
+
+/datum/random_fact/steps/life_grab_stat(mob/fact_mob)
+	return (fact_mob.life_steps_total * 0.12)
+
+/datum/random_fact/steps/death_grab_stat(datum/entity/statistic/death/fact_death)
+	return (fact_death.total_steps * 0.12)

--- a/code/game/gamemodes/cm_process.dm
+++ b/code/game/gamemodes/cm_process.dm
@@ -109,13 +109,21 @@ of predators), but can be added to include variant game modes (like humans vs. h
 	sleep(2 SECONDS)
 	to_chat_spaced(world, margin_bottom = 0, html = SPAN_ROLE_BODY("|______________________|"))
 	to_world(SPAN_ROLE_HEADER("FUN FACTS"))
-	var/list/fact_types = subtypesof(/datum/random_fact)
+	var/list/fact_types = shuffle(subtypesof(/datum/random_fact))
+	var/facts_so_far = 0
 	for(var/fact_type as anything in fact_types)
-		var/datum/random_fact/fact_human = new fact_type(set_check_human = TRUE, set_check_xeno = FALSE)
-		fact_human.announce()
+		var/datum/random_fact/fact_human = new fact_type(check_human=TRUE, check_xeno=FALSE)
+		if(fact_human.announce())
+			facts_so_far++
+		if(facts_so_far >= MAX_FACTION_FACTS_TO_ANNOUNCE)
+			break
+	facts_so_far = 0
 	for(var/fact_type as anything in fact_types)
-		var/datum/random_fact/fact_xeno = new fact_type(set_check_human = FALSE, set_check_xeno = TRUE)
-		fact_xeno.announce()
+		var/datum/random_fact/fact_xeno = new fact_type(check_human=FALSE, check_xeno=TRUE)
+		if(fact_xeno.announce())
+			facts_so_far++
+		if(facts_so_far >= MAX_FACTION_FACTS_TO_ANNOUNCE)
+			break
 	to_chat_spaced(world, margin_top = 0, html = SPAN_ROLE_BODY("|______________________|"))
 
 //===================================================\\

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -723,6 +723,7 @@
 #include "code\datums\statistics\random_facts\kills_fact.dm"
 #include "code\datums\statistics\random_facts\random_fact.dm"
 #include "code\datums\statistics\random_facts\revives_fact.dm"
+#include "code\datums\statistics\random_facts\steps_facts.dm"
 #include "code\datums\status_effects\_status_effect.dm"
 #include "code\datums\status_effects\_status_effect_helpers.dm"
 #include "code\datums\status_effects\grouped_effect.dm"


### PR DESCRIPTION
# About the pull request

Ports [#9794](https://github.com/cmss13-devs/cmss13/pull/9794), [#9898](https://github.com/cmss13-devs/cmss13/pull/9898), [#9937](https://github.com/cmss13-devs/cmss13/pull/9937) and [#10972](https://github.com/cmss13-devs/cmss13/pull/10972) from PVP, making the end of round facts pick from a list of clients that have met the minimum requirements for said facts (steps taken, kills gotten, damage taken, as examples) rather than the highest fragger/tanker.

The only aspect of the PR's that aren't directly ported is the removal of a client proc that we don't have here in 9794.

To quote Drathek & Basil, who did the original PRs over on pvp:

- Only 5 facts per faction are displayed (only 5 exist currently but future proofs other facts being added)
- Facts are only displayed for players who are still in the GLOB.directory (connected)
- Facts can specify a probability to try dead first
- Other than festivizer fact, facts are just the first person in the shuffled list to meet min_required
- Adds autodoc comments for /datum/random_fact

========================================

- This PR adds a minimum floor to most fun facts, and also re-adds the calories burned fun fact!
- Changes the calories burnt fun fact to be more 'realistic' (on the upper end of calories burnt for your average fully-encumbered marine in streneous combat conditions as in CM), while increasing the min requirement to compensate, plus changed 'damage taken' to be a bit higher since your average marine gets absolutely shattered every round.

Changelog is copied directly from the corresponding PRs

# Explain why it's good for the game

In an ideal world, it'll help quell the frag-focus some people exhibit. I'm not _that_ optimistic, however. It does mean that people beside the top fragger or face-tanker of the round have a chance of being mentioned. The steps-taken/calories burnt fact returns too!

# Testing Photographs and Procedure
Tested locally, seemed to be working without issue.

# Changelog

:cl: Drathek, Basilherb
add: Fun facts are now randomized (meaning just mentions first player meeting a minimum is mentioned - not a top stat) and are only displayed for currently connected players 
add: Fun facts can now have whitelist/blacklists for role and faction. Namely this now prevents lessers and huggers from generating fun facts, and larva from generating kills fun facts (burst)
add: Added a minimum floor for most fun facts.
add: Re-introduces the 'calories burned' fun fact, value of calories burnt increased from initial value along with minimum floor for the fact.
/:cl:
